### PR TITLE
Fix linking problems with libav* libraries on windows

### DIFF
--- a/.github/actions/download/action.yml
+++ b/.github/actions/download/action.yml
@@ -11,11 +11,21 @@ runs:
   using: composite
   steps:
     - name: Env to output
+      if: |
+        !(inputs.platform == 'windows-x86_64')
       shell: bash
       run: |
         PACKAGE_NAME=ffmpeg.${{ inputs.platform }}.tar.gz
         echo "package_name=$PACKAGE_NAME" >> $GITHUB_ENV
         echo "$PACKAGE_NAME/ffmpeg.${{ inputs.platform }}.tar.gz" >> package_paths.env
+    - name: Env to output for Windows
+      if: |
+        inputs.platform == 'windows-x86_64'
+      shell: bash
+      run: |
+        PACKAGE_NAME=ffmpeg.${{ inputs.platform }}.zip
+        echo "package_name=$PACKAGE_NAME" >> $GITHUB_ENV
+        echo "$PACKAGE_NAME/ffmpeg.${{ inputs.platform }}.zip" >> package_paths.env
     - uses: actions/download-artifact@v4
       with:
         name: ${{ env.package_name }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
         id: extract_version
         run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
-  build:
+  build-linux:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -33,15 +33,11 @@ jobs:
             arch: aarch64
             os: linux
             cross-prefix: aarch64-linux-gnu-
-          - name: windows-x86_64
-            arch: x86_64
-            os: mingw32
-            cross-prefix: x86_64-w64-mingw32-
     needs: set-version
     env:
       VERSION: ${{ needs.set-version.outputs.version }}
     steps:
-      - name: Check out the repo
+      - name: Check out FFmpeg
         uses: actions/checkout@v4
         with:
           repository: FFmpeg/FFmpeg
@@ -54,13 +50,10 @@ jobs:
           if [[ "${{ matrix.platform.name }}" == "linux-arm64" ]]; then
           sudo apt-get install -qq g++-aarch64-linux-gnu qemu-user
           fi
-          if [[ "${{ matrix.platform.name }}" == "windows-x86_64" ]]; then
-          sudo apt-get install -qq mingw-w64 gcc-mingw-w64
-          fi
 
       - name: Build FFmpeg
         run: |
-            ./configure --prefix=$(pwd)/build_output --cross-prefix="${{ matrix.platform.cross-prefix }}" --enable-cross-compile --target-os="${{ matrix.platform.os }}" --arch="${{ matrix.platform.arch }}" --extra-cflags="-DLIBTWOLAME_STATIC" --extra-ldflags="-pthread" --disable-programs --disable-doc --disable-network --disable-everything --enable-protocol=file --enable-decoder=h264 --enable-parser=h264 --enable-demuxer=h264 --enable-muxer=mp4 --enable-pic --disable-asm
+            ./configure --prefix=$(pwd)/build_output --cross-prefix="${{ matrix.platform.cross-prefix }}" --enable-cross-compile --target-os="${{ matrix.platform.os }}" --arch="${{ matrix.platform.arch }}" --extra-cflags="-DLIBTWOLAME_STATIC" --extra-ldflags="-pthread" --disable-programs --disable-doc --disable-network --disable-everything --enable-protocol=file --enable-decoder=h264 --enable-parser=h264 --enable-demuxer=h264 --enable-muxer=mp4 --enable-pic --disable-dxva2 --disable-asm
             make -j$(nproc)
             make install
 
@@ -82,6 +75,58 @@ jobs:
           name: ffmpeg.${{ matrix.platform.name }}.tar.gz
           path: ffmpeg.${{ matrix.platform.name }}.tar.gz
 
+  build-windows:
+    runs-on: windows-2022
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - name: windows-x86_64
+    needs: set-version
+    env:
+      VERSION: ${{ needs.set-version.outputs.version }}
+    steps:
+      - name: Check out FFmpeg
+        uses: actions/checkout@v4
+        with:
+          repository: FFmpeg/FFmpeg
+          ref: release/${{ env.VERSION }}
+
+      - uses: msys2/setup-msys2@v2
+
+      - name: Install dependencies
+        shell: msys2 {0}
+        run: |
+          pacman -S --noconfirm base-devel
+
+      - name: Build FFmpeg
+        shell: msys2 {0}
+        run: | 
+          curl -L https://raw.githubusercontent.com/${{ github.repository }}/refs/heads/master/vcvars.sh -o vcvars.sh
+          source ./vcvars.sh
+          ./configure --prefix=$(pwd)/build_output --toolchain=msvc --target-os=win64 --arch=x86_64 --disable-programs --disable-doc --disable-network --disable-everything --enable-protocol=file --enable-decoder=h264 --enable-parser=h264 --enable-demuxer=h264 --enable-muxer=mp4 --enable-pic --disable-dxva2 --disable-asm
+          make -j$(nproc)
+          make install
+
+      - name: Prepare for artifact
+        run: |
+          mkdir artifacts/lib
+          mkdir artifacts/include
+          move build_output/lib/libavcodec.a artifacts/lib/avcodec.lib
+          move build_output/lib/libavformat.a artifacts/lib/avformat.lib
+          move build_output/lib/libavutil.a artifacts/lib/avutil.lib
+          move build_output/include/libavcodec artifacts/include/
+          move build_output/include/libavformat artifacts/include/
+          move build_output/include/libavutil artifacts/include/
+          Compress-Archive -Path artifacts -DestinationPath ffmpeg.${{ matrix.platform.name }}.zip
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ffmpeg.${{ matrix.platform.name }}.zip
+          path: ffmpeg.${{ matrix.platform.name }}.zip
+  
+
   build-macos:
     runs-on: macos-14
     strategy:
@@ -93,7 +138,7 @@ jobs:
     env:
       VERSION: ${{ needs.set-version.outputs.version }}
     steps:
-      - name: Check out the repo
+      - name: Check out FFmpeg
         uses: actions/checkout@v4
         with:
           repository: FFmpeg/FFmpeg
@@ -127,7 +172,8 @@ jobs:
     name: Create Release
     if: contains(github.ref, 'tags/v')
     needs:
-      - build
+      - build-linux
+      - build-windows
       - build-macos
     runs-on: ubuntu-latest
     steps:

--- a/vcvars.sh
+++ b/vcvars.sh
@@ -1,0 +1,50 @@
+# vcvarsall.bat-like script for msys2 bash
+vs_base_path="/c/Program Files/Microsoft Visual Studio"
+windows_kits_base_path="/c/Program Files (x86)/Windows Kits/10"
+
+get_vs_edition() {
+    #get year and edition
+    local vs_year=$(ls -1 "$vs_base_path" | grep -Eo '[0-9]{4}')
+    #get latest year
+    vs_year=$(echo "$vs_year" | sort -nr | head -n1)
+    #new base path
+    local vs_base_path="$vs_base_path/$vs_year"
+    #get edition
+    local vs_edition=$(ls -1 "$vs_base_path" | grep -Eo 'Community|Professional|Enterprise')
+    #get the best edition in order enterprise, professional, community
+    if [ -d "$vs_base_path/Enterprise" ]; then
+        vs_edition="Enterprise"
+    elif [ -d "$vs_base_path/Professional" ]; then
+        vs_edition="Professional"
+    elif [ -d "$vs_base_path/Community" ]; then
+        vs_edition="Community"
+    fi
+    echo "$vs_year/$vs_edition"
+}
+
+get_msvc_version() {
+    #get msvc version
+    vs_edition=$1
+    local msvc_version=$(ls -1 "$vs_base_path/$vs_edition/VC/Tools/MSVC" | grep -Eo '[0-9.]+')
+    #get latest version
+    msvc_version=$(echo "$msvc_version" | sort -nr | head -n1)
+    echo "$msvc_version"
+}
+
+get_windows_kits_version() {
+    #get windows kits version
+    local windows_kits_version=$(ls -1 "$windows_kits_base_path/Include" | grep -Eo '[0-9.]+')
+    #get latest version
+    windows_kits_version=$(echo "$windows_kits_version" | sort -nr | head -n1)
+    echo "$windows_kits_version"
+}
+
+
+vs_edition="$(get_vs_edition)"
+msvc_version="$(get_msvc_version $vs_edition)"
+windows_kits_version="$(get_windows_kits_version)"
+
+export PATH="$vs_base_path/$vs_edition/VC/Tools/MSVC/$msvc_version/bin/Hostx64/x64:$PATH"
+export LIB="$vs_base_path/$vs_edition/VC/Tools/MSVC/$msvc_version/lib/x64:$windows_kits_base_path/Lib/$windows_kits_version/um/x64:$windows_kits_base_path/Lib/$windows_kits_version/ucrt/x64"
+export INCLUDE="$vs_base_path/$vs_edition/VC/Tools/MSVC/$msvc_version/include:$windows_kits_base_path/Include/$windows_kits_version/ucrt:$windows_kits_base_path/Include/$windows_kits_version/um:$windows_kits_base_path/Include/$windows_kits_version/shared"
+echo "Correctly set env vars for Visual Studio $vs_edition, MSVC $msvc_version and Windows Kits $windows_kits_version"


### PR DESCRIPTION
Windows build now uses MSVC to avoid problems while linking libav* libs built from mingw